### PR TITLE
add [siblings] has_parent option

### DIFF
--- a/page-list.php
+++ b/page-list.php
@@ -34,7 +34,8 @@ $pagelist_unq_settings = array(
 		'link_after' => '',
 		'post_type' => 'page',
 		'post_status' => 'publish',
-		'class' => ''
+		'class' => '',
+		'has_parent' => -1
 	)
 );
 
@@ -170,7 +171,9 @@ if ( !function_exists('siblings_unqprfx_shortcode') ) {
 		$list_pages = wp_list_pages( $page_list_args );
 
 		$return .= $pagelist_unq_settings['powered_by'];
-		if ($list_pages) {
+		if (!( !empty( $offset ) && is_numeric( $offset ) && $offset_count > $offset & $post->post_parent) 
+		    && (!empty( $has_parent ) && is_numeric( $has_parent ) && ($has_parent==-1 | ($has_parent==0 && !$post->post_parent) | ($has_parent==1 && $post->post_parent)) )
+		    && $list_pages) {
 			$return .= '<ul class="page-list siblings-page-list '.esc_attr($class).'">'."\n".$list_pages."\n".'</ul>';
 		} else {
 			$return .= '<!-- no pages to show -->';

--- a/page-list.php
+++ b/page-list.php
@@ -171,9 +171,16 @@ if ( !function_exists('siblings_unqprfx_shortcode') ) {
 		$list_pages = wp_list_pages( $page_list_args );
 
 		$return .= $pagelist_unq_settings['powered_by'];
-		if ($list_pages && !(is_numeric( $offset ) && $offset_count > $offset && $post->post_parent) 
-		    && (is_numeric( $has_parent ) && ($has_parent==-1 || ($has_parent==0 && !$post->post_parent) || ($has_parent==1 && $post->post_parent)) )
-		     ) {
+		$parent_exists = isset($post) && !empty($post->post_parent);
+		$has_parent    = is_numeric($has_parent) ? (int) $has_parent : -1;
+		if (
+			$list_pages
+			&& (
+				$has_parent === -1
+				|| ($has_parent === 0 && !$parent_exists)
+				|| ($has_parent === 1 &&  $parent_exists)
+			)
+		) {
 			$return .= '<ul class="page-list siblings-page-list '.esc_attr($class).'">'."\n".$list_pages."\n".'</ul>';
 		} else {
 			$return .= '<!-- no pages to show -->';

--- a/page-list.php
+++ b/page-list.php
@@ -171,9 +171,9 @@ if ( !function_exists('siblings_unqprfx_shortcode') ) {
 		$list_pages = wp_list_pages( $page_list_args );
 
 		$return .= $pagelist_unq_settings['powered_by'];
-		if (!( !empty( $offset ) && is_numeric( $offset ) && $offset_count > $offset & $post->post_parent) 
-		    && (!empty( $has_parent ) && is_numeric( $has_parent ) && ($has_parent==-1 | ($has_parent==0 && !$post->post_parent) | ($has_parent==1 && $post->post_parent)) )
-		    && $list_pages) {
+		if ($list_pages && !(is_numeric( $offset ) && $offset_count > $offset && $post->post_parent) 
+		    && (is_numeric( $has_parent ) && ($has_parent==-1 || ($has_parent==0 && !$post->post_parent) || ($has_parent==1 && $post->post_parent)) )
+		     ) {
 			$return .= '<ul class="page-list siblings-page-list '.esc_attr($class).'">'."\n".$list_pages."\n".'</ul>';
 		} else {
 			$return .= '<!-- no pages to show -->';

--- a/readme.txt
+++ b/readme.txt
@@ -57,7 +57,8 @@ License URI: http://www.gnu.org/licenses/gpl.html
 * **link_before** - sets the text or html that precedes the link text inside link tag: `[pagelist link_before="<span>"]`; you may specify html tags only in the `HTML` tab in your Rich-text editor;
 * **link_after** - sets the text or html that follows the link text inside link tag: `[pagelist link_after="</span>"]`; you may specify html tags only in the `HTML` tab in your Rich-text editor;
 * **class** - the CSS class for list of pages: `[pagelist class="listclass"]`; by default the class is empty (class="");
-* columns - for splitting list of pages into columns: `[pagelist class="page-list-cols-2"]`; available classes: page-list-cols-2, page-list-cols-3, page-list-cols-4, page-list-cols-5; works in all modern browsers and IE10+; columns are responsive and become 1 column at less than 768px;
+* **columns** - for splitting list of pages into columns: `[pagelist class="page-list-cols-2"]`; available classes: page-list-cols-2, page-list-cols-3, page-list-cols-4, page-list-cols-5; works in all modern browsers and IE10+; columns are responsive and become 1 column at less than 768px;
+* **has_parent** - to display list only on if page has parent page `[siblings has_parent="1"]` or does not have parent page `[siblings has_parent="0"]` 
 
 More [info about params](http://codex.wordpress.org/Function_Reference/wp_list_pages#Parameters) for [pagelist], [subpages], [siblings].
 


### PR DESCRIPTION
It is useful to have it for display siblings menu on sidebar only on pages with parent page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tri-state "has_parent" parameter for sibling lists so lists can be shown only when a page has a parent, has no parent, or in a neutral state; the shortcode now suppresses output when the selected condition isn't met.

* **Documentation**
  * Updated plugin docs to describe the new "has_parent" parameter and improved parameter formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->